### PR TITLE
Include @seealso in RSkittleBrewer.R

### DIFF
--- a/R/RSkittleBrewer.R
+++ b/R/RSkittleBrewer.R
@@ -12,6 +12,7 @@
 #' plotSkittles()
 #' plotSmarties()
 #'
+#' @seealso \code{\link{plotSkittles}}, \code{\link{plotSmarties}}
 #' @keywords hplot
 RSkittleBrewer <-
 function(flavor=c('original','tropical','wildberry','M&M','smarties'))

--- a/man/RSkittleBrewer.Rd
+++ b/man/RSkittleBrewer.Rd
@@ -20,5 +20,8 @@ Vectors of colors corresponding to different candies.
 plotSkittles()
 plotSmarties()
 }
+\seealso{
+\code{\link{plotSkittles}}, \code{\link{plotSmarties}}
+}
 \keyword{hplot}
 


### PR DESCRIPTION
I'd forgotten to include @seealso pointing from the RSkittleBrewer function to the two plot functions.

(I'm using your package as an example in a lecture on writing R packages in my [Tools for Reproducible Research](http://kbroman.github.io/Tools4RR) course.)
