### PR TITLE
Change version, 1.01 -> 1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RSkittleBrewer
-Version: 1.01
+Version: 1.1
 Author: Alyssa Frazee
 Maintainer: Alyssa Frazee <afrazee@jhsph.edu>
 License: MIT + file LICENSE


### PR DESCRIPTION
Sorry to bother you again, but...

I was reading the R-ext manual, and it say not to use version numbers like 1.01, 1.02, ..., but rather use 1.1, 1.2, ...

(The 1.01 was [my fault](https://github.com/alyssafrazee/RSkittleBrewer/commit/518b68c9).)
