### PR TITLE
minor fix to install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you want high-quality, scientifically-researched color schemes for your R plo
 with `devtools`:
 
 ```S
-devtools::install_github('alyssafrazee/RSkitleBrewer')
+devtools::install_github('alyssafrazee/RSkittleBrewer')
 ```
 
 ### use

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you want high-quality, scientifically-researched color schemes for your R plo
 with `devtools`:
 
 ```S
-devtools::install_github('RSkittleBrewer', 'alyssafrazee')
+devtools::install_github('alyssafrazee/RSkitleBrewer')
 ```
 
 ### use


### PR DESCRIPTION
The devtools::install_github username parameter is deprecated. Updated README to new style.
